### PR TITLE
fix error when building

### DIFF
--- a/Projects/Generic Example/include/backend_functions.h
+++ b/Projects/Generic Example/include/backend_functions.h
@@ -93,7 +93,7 @@ void trigger_CAN_TX(void);
 uint8_t add_to_CAN_RX_Queue(CAN_Bus bus, bool EXT_ID, uint32_t ID, uint8_t DLC, uint8_t rxData[8]);
 
 // Arithmatic Functions related to CAN Reception and Transmission //
-float process_float_value(uint32_t value, uint32_t bitmask, bool is_signed, float factor, float offset, int8_t decimal_places);
+float process_float_value(uint32_t value, uint32_t bitmask, bool is_signed, float factor, float offset, uint8_t decimal_places);
 int32_t process_int_value(uint32_t value, uint32_t bitmask, bool is_signed, int32_t factor, int32_t offset);
 uint32_t process_unsigned_int_value(uint32_t value, uint32_t bitmask, uint32_t factor, uint32_t offset);
 uint32_t process_raw_value(uint32_t value, uint32_t bitmask);


### PR DESCRIPTION
Fixes the following error when building:

![Screenshot 2025-02-17 180045](https://github.com/user-attachments/assets/ebd8d179-1592-4a4c-ba70-0153674aacd0)

It looks like you set "decimal_places" to uint8_t but missed it here.